### PR TITLE
FIX: Normalize values input from cli into IPLD type values

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "cSpell.words": [
+        "IPLD",
+        "promptui"
+    ],
+    "cSpell.enableFiletypes": [
+        "!go"
+    ]
+}


### PR DESCRIPTION
All values from the speedway cli were being set as strings to the object builder. This prevented non-string IPLD types from being set through the form builder.

## Changes

- Added method which maps the golang type with the specified IPLD Kind, and then utilizes `strconv` to attempt to normalize the value

## Checklist

- [X] Unit tests
- [X] Documentation

Fixes 
Connects 


<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>