### PR TITLE
create rpc server daemon

### DIFF
--- a/cmd/speedway-cli/speedwaycmd/daemon/daemon.go
+++ b/cmd/speedway-cli/speedwaycmd/daemon/daemon.go
@@ -1,0 +1,22 @@
+package daemon
+
+import (
+	"context"
+
+	"github.com/kataras/golog"
+	"github.com/spf13/cobra"
+)
+
+func BootstrapDaemonCommand(ctx context.Context, logger *golog.Logger) (daemonCmd *cobra.Command) {
+	daemonCmd = &cobra.Command{
+		Use:   "daemon [command]",
+		Short: "Commands for daemons to interact with.",
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+
+	logger = logger.Child("[Daemon] ")
+
+	daemonCmd.AddCommand(bootstrapStartDaemonCommand(ctx, logger))
+
+	return
+}

--- a/cmd/speedway-cli/speedwaycmd/daemon/start.go
+++ b/cmd/speedway-cli/speedwaycmd/daemon/start.go
@@ -1,0 +1,35 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/kataras/golog"
+	"github.com/sonr-io/speedway/internal/daemon"
+	"github.com/spf13/cobra"
+)
+
+func bootstrapStartDaemonCommand(ctx context.Context, logger *golog.Logger) (startCmd *cobra.Command) {
+	startCmd = &cobra.Command{
+		Use:   "start [port]",
+		Short: "Starts the Speedway daemon.",
+		Long: `Sets up a GRPC server daemon which contains a local Motor instance.
+		This daemon allows the user to stay logged in between speedway sessions.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			var port int64
+			if len(args) < 1 {
+				port = 6868
+			} else {
+				p, err := strconv.ParseInt(args[0], 10, 64)
+				if err != nil {
+					fmt.Printf("Error parsing port: %s", err)
+					return
+				}
+				port = p
+			}
+			fmt.Println(daemon.Start(int(port)))
+		},
+	}
+	return
+}

--- a/cmd/speedway-cli/speedwaycmd/root.go
+++ b/cmd/speedway-cli/speedwaycmd/root.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kataras/golog"
 	bucket "github.com/sonr-io/speedway/cmd/speedway-cli/speedwaycmd/bucket"
+	daemon "github.com/sonr-io/speedway/cmd/speedway-cli/speedwaycmd/daemon"
 	object "github.com/sonr-io/speedway/cmd/speedway-cli/speedwaycmd/object"
 	registry "github.com/sonr-io/speedway/cmd/speedway-cli/speedwaycmd/registry"
 	schema "github.com/sonr-io/speedway/cmd/speedway-cli/speedwaycmd/schema"
@@ -29,6 +30,7 @@ func bootstrapRootCommand(ctx context.Context, logger *golog.Logger) (rootCmd *c
 	rootCmd.AddCommand(schema.BootstrapSchemaCommand(ctx, logger))
 	rootCmd.AddCommand(object.BootstrapObjectCommand(ctx, logger))
 	rootCmd.AddCommand(bucket.BootstrapBucketCommand(ctx, logger))
+	rootCmd.AddCommand(daemon.BootstrapDaemonCommand(ctx, logger))
 	rootCmd.AddCommand(BootstrapServeCommand(ctx))
 
 	return

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1,0 +1,50 @@
+package daemon
+
+import (
+	"fmt"
+	"github.com/sonr-io/speedway/internal/binding"
+	"net"
+	"net/rpc"
+)
+
+var (
+	kill    chan bool
+	handler *Daemon
+)
+
+type Daemon int
+
+func NewHandler() (*Daemon, error) {
+	h := new(Daemon)
+	if err := rpc.Register(h); err != nil {
+		return nil, fmt.Errorf("register rpc handler: %s", err)
+	}
+
+	return h, nil
+}
+
+func Start(port int) error {
+	fmt.Printf("Starting daemon on port %d... ", port)
+	l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		return fmt.Errorf("start RPC server: %s", err)
+	}
+
+	binding.InitMotor()
+	handler, err = NewHandler()
+	if err != nil {
+		return err
+	}
+	kill = make(chan bool)
+
+	go func() {
+		for {
+			rpc.Accept(l)
+		}
+	}()
+	fmt.Println("done.")
+
+	<-kill
+	fmt.Println("Killing daemon...")
+	return nil
+}

--- a/internal/daemon/registry.go
+++ b/internal/daemon/registry.go
@@ -1,0 +1,27 @@
+package daemon
+
+import (
+	"fmt"
+
+	rtmv1 "github.com/sonr-io/sonr/third_party/types/motor/api/v1"
+)
+
+func (d *Daemon) CreateAccount(req rtmv1.CreateAccountRequest, res *rtmv1.CreateAccountResponse) error {
+	*res = rtmv1.CreateAccountResponse{}
+	return fmt.Errorf("TODO: not implemented")
+}
+
+func (d *Daemon) CreateAccountWithKeys(req rtmv1.CreateAccountWithKeysRequest, res *rtmv1.CreateAccountWithKeysResponse) error {
+	*res = rtmv1.CreateAccountWithKeysResponse{}
+	return fmt.Errorf("TODO: not implemented")
+}
+
+func (d *Daemon) Login(req rtmv1.LoginRequest, res *rtmv1.LoginResponse) error {
+	*res = rtmv1.LoginResponse{}
+	return fmt.Errorf("TODO: not implemented")
+}
+
+func (d *Daemon) LoginWithKeys(req rtmv1.LoginWithKeysRequest, res *rtmv1.LoginResponse) error {
+	*res = rtmv1.LoginResponse{}
+	return fmt.Errorf("TODO: not implemented")
+}


### PR DESCRIPTION
The first in a series of PRs to daemonize speedway.

- [x] Add command `speedway daemon start` to create an RPC server
- [ ] Add registry RPC handlers for motor commands
- [ ] Add schema RPC handlers for motor commands
- [ ] Add bucket RPC handlers for motor commands

## Changes

- Add `daemon` package and command.

Updates #155 

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>