### PR TITLE
Add daemon registry methods

### DIFF
--- a/internal/binding/binding.go
+++ b/internal/binding/binding.go
@@ -101,6 +101,22 @@ func (b *SpeedwayBinding) CreateAccount(req rtmv1.CreateAccountRequest) (rtmv1.C
 }
 
 /*
+Create Account With Keys on Blockchain and return the response
+*/
+func (b *SpeedwayBinding) CreateAccountWithKeys(req rtmv1.CreateAccountWithKeysRequest) (rtmv1.CreateAccountWithKeysResponse, error) {
+	res, err := b.Instance.CreateAccountWithKeys(req)
+	if err != nil {
+		fmt.Println(status.Error("Create Account With Keys Error"), err)
+	}
+
+	if storage.StoreInfo("address.snr", b.Instance) != nil {
+		fmt.Println(status.Error("Storage Error: "), err)
+	}
+
+	return res, err
+}
+
+/*
 Login and return the response
 Set the logged in flag to true if successful
 */
@@ -113,6 +129,28 @@ func (b *SpeedwayBinding) Login(req rtmv1.LoginRequest) (rtmv1.LoginResponse, er
 	}
 
 	res, err := b.Instance.Login(req)
+	if err != nil {
+		fmt.Println(status.Error("Login Error"), err)
+	}
+
+	b.loggedIn = true
+
+	return res, err
+}
+
+/*
+Login With Keys and return the response
+Set the logged in flag to true if successful
+*/
+func (b *SpeedwayBinding) LoginWithKeys(req rtmv1.LoginWithKeysRequest) (rtmv1.LoginResponse, error) {
+	if b.Instance == nil {
+		return rtmv1.LoginResponse{}, ErrMotorNotInitialized
+	}
+	if b.loggedIn {
+		fmt.Println(status.Info, "You are already logged in")
+	}
+
+	res, err := b.Instance.LoginWithKeys(req)
 	if err != nil {
 		fmt.Println(status.Error("Login Error"), err)
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -12,7 +12,9 @@ var (
 	handler *Daemon
 )
 
-type Daemon int
+type Daemon struct {
+	instance *binding.SpeedwayBinding
+}
 
 func NewHandler() (*Daemon, error) {
 	h := new(Daemon)
@@ -30,11 +32,11 @@ func Start(port int) error {
 		return fmt.Errorf("start RPC server: %s", err)
 	}
 
-	binding.InitMotor()
 	handler, err = NewHandler()
 	if err != nil {
 		return err
 	}
+	handler.instance = binding.CreateInstance()
 	kill = make(chan bool)
 
 	go func() {

--- a/internal/daemon/registry.go
+++ b/internal/daemon/registry.go
@@ -1,27 +1,43 @@
 package daemon
 
 import (
-	"fmt"
+	"context"
 
 	rtmv1 "github.com/sonr-io/sonr/third_party/types/motor/api/v1"
+	rt "github.com/sonr-io/sonr/x/registry/types"
 )
 
-func (d *Daemon) CreateAccount(req rtmv1.CreateAccountRequest, res *rtmv1.CreateAccountResponse) error {
-	*res = rtmv1.CreateAccountResponse{}
-	return fmt.Errorf("TODO: not implemented")
+func (d *Daemon) CreateAccount(req rtmv1.CreateAccountRequest, res *rtmv1.CreateAccountResponse) (err error) {
+	*res, err = d.instance.CreateAccount(req)
+	return
 }
 
-func (d *Daemon) CreateAccountWithKeys(req rtmv1.CreateAccountWithKeysRequest, res *rtmv1.CreateAccountWithKeysResponse) error {
-	*res = rtmv1.CreateAccountWithKeysResponse{}
-	return fmt.Errorf("TODO: not implemented")
+func (d *Daemon) CreateAccountWithKeys(req rtmv1.CreateAccountWithKeysRequest, res *rtmv1.CreateAccountWithKeysResponse) (err error) {
+	*res, err = d.instance.CreateAccountWithKeys(req)
+	return
 }
 
-func (d *Daemon) Login(req rtmv1.LoginRequest, res *rtmv1.LoginResponse) error {
-	*res = rtmv1.LoginResponse{}
-	return fmt.Errorf("TODO: not implemented")
+func (d *Daemon) Login(req rtmv1.LoginRequest, res *rtmv1.LoginResponse) (err error) {
+	*res, err = d.instance.Login(req)
+	return
 }
 
-func (d *Daemon) LoginWithKeys(req rtmv1.LoginWithKeysRequest, res *rtmv1.LoginResponse) error {
-	*res = rtmv1.LoginResponse{}
-	return fmt.Errorf("TODO: not implemented")
+func (d *Daemon) LoginWithKeys(req rtmv1.LoginWithKeysRequest, res *rtmv1.LoginResponse) (err error) {
+	*res, err = d.instance.LoginWithKeys(req)
+	return
+}
+
+func (d *Daemon) BuyAlias(req rt.MsgBuyAlias, res *rt.MsgBuyAliasResponse) (err error) {
+	*res, err = d.instance.BuyAlias(context.Background(), req)
+	return
+}
+
+func (d *Daemon) SellAlias(req rt.MsgSellAlias, res *rt.MsgSellAliasResponse) (err error) {
+	*res, err = d.instance.SellAlias(context.Background(), req)
+	return
+}
+
+func (d *Daemon) TransferAlias(req rt.MsgTransferAlias, res *rt.MsgTransferAliasResponse) (err error) {
+	*res, err = d.instance.TransferAlias(context.Background(), req)
+	return
 }


### PR DESCRIPTION
Adds registry handlers to daemon

- [x] Add command `speedway daemon start` to create an RPC server
- [x] Add registry RPC handlers for motor commands
- [ ] Add schema RPC handlers for motor commands
- [ ] Add bucket RPC handlers for motor commands

Updates #155 

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>