### PR TITLE
Add Schema RPC and client methods

### DIFF
--- a/internal/binding/binding.go
+++ b/internal/binding/binding.go
@@ -161,7 +161,7 @@ func (b *SpeedwayBinding) LoginWithKeys(req rtmv1.LoginWithKeysRequest) (rtmv1.L
 }
 
 /*
-Get the object and return a map of the object
+ [DEPRECATED] Get the object and return a map of the object
 */
 func (b *SpeedwayBinding) GetObject(ctx context.Context, schemaDid string, cid string) (*object.Object, error) {
 	if b.Instance == nil {
@@ -199,6 +199,21 @@ func (b *SpeedwayBinding) GetObject(ctx context.Context, schemaDid string, cid s
 	}
 
 	return &getObject, nil
+}
+
+/*
+Get a SchemaDocument from motor
+*/
+func (b *SpeedwayBinding) GetSchemaDocument(req rtmv1.GetDocumentRequest) (rtmv1.GetDocumentResponse, error) {
+	if b.Instance == nil {
+		return rtmv1.GetDocumentResponse{}, ErrMotorNotInitialized
+	}
+	if !b.loggedIn {
+		return rtmv1.GetDocumentResponse{}, ErrNotAuthenticated
+	}
+
+	res, err := b.Instance.GetDocument(req)
+	return *res, err
 }
 
 /*

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,0 +1,21 @@
+package client
+
+import (
+	"fmt"
+	"net/rpc"
+)
+
+type RpcClient struct {
+	client *rpc.Client
+}
+
+func New(port int) (*RpcClient, error) {
+	client, err := rpc.Dial("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		return nil, err
+	}
+
+	return &RpcClient{
+		client: client,
+	}, nil
+}

--- a/internal/client/registry.go
+++ b/internal/client/registry.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	rtmv1 "github.com/sonr-io/sonr/third_party/types/motor/api/v1"
+	rt "github.com/sonr-io/sonr/x/registry/types"
+)
+
+func (c *RpcClient) CreateAccount(req rtmv1.CreateAccountRequest) (*rtmv1.CreateAccountResponse, error) {
+	var response rtmv1.CreateAccountResponse
+	if err := c.client.Call("Daemon.CreateAccount", req, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *RpcClient) CreateAccountWithKeys(req rtmv1.CreateAccountWithKeysRequest) (*rtmv1.CreateAccountWithKeysResponse, error) {
+	var response rtmv1.CreateAccountWithKeysResponse
+	if err := c.client.Call("Daemon.CreateAccountWithKeys", req, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *RpcClient) Login(req rtmv1.LoginRequest) (*rtmv1.LoginResponse, error) {
+	var response rtmv1.LoginResponse
+	if err := c.client.Call("Daemon.Login", req, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *RpcClient) LoginWithKeys(req rtmv1.LoginWithKeysRequest) (*rtmv1.LoginResponse, error) {
+	var response rtmv1.LoginResponse
+	if err := c.client.Call("Daemon.LoginWithKeys", req, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *RpcClient) BuyAlias(req rt.MsgBuyAlias) (*rt.MsgBuyAliasResponse, error) {
+	var response rt.MsgBuyAliasResponse
+	if err := c.client.Call("Daemon.BuyAlias", req, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *RpcClient) SellAlias(req rt.MsgSellAlias) (*rt.MsgSellAliasResponse, error) {
+	var response rt.MsgSellAliasResponse
+	if err := c.client.Call("Daemon.SellAlias", req, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *RpcClient) TransferAlias(req rt.MsgTransferAlias) (*rt.MsgTransferAliasResponse, error) {
+	var response rt.MsgTransferAliasResponse
+	if err := c.client.Call("Daemon.TransferAlias", req, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}

--- a/internal/client/schema.go
+++ b/internal/client/schema.go
@@ -1,0 +1,37 @@
+package client
+
+import (
+	rtmv1 "github.com/sonr-io/sonr/third_party/types/motor/api/v1"
+)
+
+func (c *RpcClient) CreateSchema(req rtmv1.CreateSchemaRequest) (*rtmv1.CreateSchemaResponse, error) {
+	var response rtmv1.CreateSchemaResponse
+	if err := c.client.Call("Daemon.CreateSchema", req, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *RpcClient) GetSchema(req rtmv1.QuerySchemaRequest) (*rtmv1.QueryWhatIsResponse, error) {
+	var response rtmv1.QueryWhatIsResponse
+	if err := c.client.Call("Daemon.GetSchema", req, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *RpcClient) CreateSchemaDocument(req rtmv1.UploadDocumentRequest) (*rtmv1.UploadDocumentResponse, error) {
+	var response rtmv1.UploadDocumentResponse
+	if err := c.client.Call("Daemon.CreateSchemaDocument", req, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *RpcClient) GetSchemaDocument(req rtmv1.GetDocumentRequest) (*rtmv1.GetDocumentResponse, error) {
+	var response rtmv1.GetDocumentResponse
+	if err := c.client.Call("Daemon.GetSchemaDocument", req, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}

--- a/internal/daemon/schema.go
+++ b/internal/daemon/schema.go
@@ -1,0 +1,16 @@
+package daemon
+
+import (
+	"context"
+	rtmv1 "github.com/sonr-io/sonr/third_party/types/motor/api/v1"
+)
+
+func (d *Daemon) CreateSchema(req rtmv1.CreateSchemaRequest, res *rtmv1.CreateSchemaResponse) (err error) {
+	*res, err = d.instance.CreateSchema(req)
+	return
+}
+
+func (d *Daemon) GetSchema(req rtmv1.QuerySchemaRequest, res *rtmv1.QueryWhatIsResponse) (err error) {
+	*res, err = d.instance.GetSchema(context.Background(), req.Creator, req.Did)
+	return
+}

--- a/internal/daemon/schema.go
+++ b/internal/daemon/schema.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+
 	rtmv1 "github.com/sonr-io/sonr/third_party/types/motor/api/v1"
 )
 
@@ -12,5 +13,17 @@ func (d *Daemon) CreateSchema(req rtmv1.CreateSchemaRequest, res *rtmv1.CreateSc
 
 func (d *Daemon) GetSchema(req rtmv1.QuerySchemaRequest, res *rtmv1.QueryWhatIsResponse) (err error) {
 	*res, err = d.instance.GetSchema(context.Background(), req.Creator, req.Did)
+	return
+}
+
+func (d *Daemon) CreateSchemaDocument(req rtmv1.UploadDocumentRequest, res *rtmv1.UploadDocumentResponse) (err error) {
+	r, e := d.instance.Instance.UploadDocument(req)
+	*res = *r
+	err = e
+	return
+}
+
+func (d *Daemon) GetSchemaDocument(req rtmv1.GetDocumentRequest, res *rtmv1.GetDocumentResponse) (err error) {
+	*res, err = d.instance.GetSchemaDocument(req)
 	return
 }


### PR DESCRIPTION
The first in a series of PRs to daemonize speedway.

- [x] Add command `speedway daemon start` to create an RPC server
- [x] Add registry RPC handlers for motor commands
- [x] Add schema RPC handlers for motor commands
- [ ] Add bucket RPC handlers for motor commands

Updates #155 

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>