### PR TITLE
Add bucket rpcs to daemon

### DIFF
--- a/internal/client/bucket.go
+++ b/internal/client/bucket.go
@@ -1,0 +1,29 @@
+package client
+
+import (
+	rtmv1 "github.com/sonr-io/sonr/third_party/types/motor/api/v1"
+)
+
+func (c *RpcClient) CreateBucket(req rtmv1.CreateBucketRequest) (*rtmv1.CreateBucketResponse, error) {
+	var response rtmv1.CreateBucketResponse
+	if err := c.client.Call("Daemon.CreateBucket", req, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *RpcClient) GetBucketsByCreator(req rtmv1.QueryWhereIsByCreatorRequest) (*rtmv1.QueryWhereIsByCreatorResponse, error) {
+	var response rtmv1.QueryWhereIsByCreatorResponse
+	if err := c.client.Call("Daemon.GetBucketsByCreator", req, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *RpcClient) GetBucketById(req rtmv1.QueryWhereIsRequest) (*rtmv1.QueryWhereIsResponse, error) {
+	var response rtmv1.QueryWhereIsResponse
+	if err := c.client.Call("Daemon.GetBucketById", req, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}

--- a/internal/daemon/bucket.go
+++ b/internal/daemon/bucket.go
@@ -1,0 +1,33 @@
+package daemon
+
+import (
+	"context"
+
+	rtmv1 "github.com/sonr-io/sonr/third_party/types/motor/api/v1"
+)
+
+func (d *Daemon) CreateBucket(req rtmv1.CreateBucketRequest, res *rtmv1.CreateBucketResponse) (err error) {
+	b, err := d.instance.Instance.CreateBucket(context.Background(), req)
+	if err != nil {
+		return err
+	}
+
+	*res = rtmv1.CreateBucketResponse{
+		Did: b.GetDID(),
+	}
+	return nil
+}
+
+func (d *Daemon) GetBucketsByCreator(req rtmv1.QueryWhereIsByCreatorRequest, res *rtmv1.QueryWhereIsByCreatorResponse) (err error) {
+	r, e := d.instance.Instance.QueryWhereIsByCreator(req)
+	*res = *r
+	err = e
+	return
+}
+
+func (d *Daemon) GetBucketById(req rtmv1.QueryWhereIsRequest, res *rtmv1.QueryWhereIsResponse) (err error) {
+	r, e := d.instance.Instance.QueryWhereIs(req)
+	*res = *r
+	err = e
+	return
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2,9 +2,10 @@ package daemon
 
 import (
 	"fmt"
-	"github.com/sonr-io/speedway/internal/binding"
 	"net"
 	"net/rpc"
+
+	"github.com/sonr-io/speedway/internal/binding"
 )
 
 var (


### PR DESCRIPTION
The first in a series of PRs to daemonize speedway.

- [x] Add command `speedway daemon start` to create an RPC server
- [x] Add registry RPC handlers for motor commands
- [x] Add schema RPC handlers for motor commands
- [x] Add bucket RPC handlers for motor commands
- [ ] Integrate RPCs into commansd
- [ ] Add bucket search methods to RPC

Updates #155 

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>