### PR TITLE
Integrate daemon into registry

### DIFF
--- a/cmd/speedway-cli/speedwaycmd/registry/Login.go
+++ b/cmd/speedway-cli/speedwaycmd/registry/Login.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Songmu/prompter"
 	"github.com/kataras/golog"
 	rtmv1 "github.com/sonr-io/sonr/third_party/types/motor/api/v1"
-	"github.com/sonr-io/speedway/internal/binding"
+	"github.com/sonr-io/speedway/internal/client"
 	"github.com/sonr-io/speedway/internal/status"
 	"github.com/spf13/cobra"
 )
@@ -32,18 +32,21 @@ func bootstrapLoginCommand(ctx context.Context, logger *golog.Logger) (loginCmd 
 				NoEcho:  true,
 			}).Prompt()
 
-			req := rtmv1.LoginRequest{
-				Did:      addr,
-				Password: password,
+			cli, err := client.New(ctx)
+			if err != nil {
+				logger.Fatalf(status.Error("RPC Client Error: "), err)
+				return
 			}
 
-			m := binding.CreateInstance()
-			res, err := m.Login(req)
+			res, err := cli.Login(rtmv1.LoginRequest{
+				Did:      addr,
+				Password: password,
+			})
 			if err != nil {
 				logger.Fatalf(status.Error("Login Error: "), err)
 				return
 			}
-			logger.Info(status.Debug, "Login Response: ", res)
+
 			if res.Success {
 				logger.Info(status.Success("Login Successful"))
 			} else {

--- a/cmd/speedway-cli/speedwaycmd/registry/Login.go
+++ b/cmd/speedway-cli/speedwaycmd/registry/Login.go
@@ -46,6 +46,7 @@ func bootstrapLoginCommand(ctx context.Context, logger *golog.Logger) (loginCmd 
 				logger.Fatalf(status.Error("Login Error: "), err)
 				return
 			}
+			logger.Info(status.Debug, "Login Response: ", res)
 
 			if res.Success {
 				logger.Info(status.Success("Login Successful"))

--- a/cmd/speedway-cli/speedwaycmd/registry/Registry.go
+++ b/cmd/speedway-cli/speedwaycmd/registry/Registry.go
@@ -22,5 +22,7 @@ func BootstrapRegistryCommand(ctx context.Context, logger *golog.Logger) (regist
 	registryCmd.AddCommand(bootstrapCreateAccountCommand(ctx, logger))
 	registryCmd.AddCommand(bootstrapLoginCommand(ctx, logger))
 	registryCmd.AddCommand(bootstrapBuyAlias(ctx, logger))
+	registryCmd.AddCommand(bootstrapSellAlias(ctx, logger))
+	registryCmd.AddCommand(bootstrapTransferAlias(ctx, logger))
 	return
 }

--- a/cmd/speedway-cli/speedwaycmd/registry/register.go
+++ b/cmd/speedway-cli/speedwaycmd/registry/register.go
@@ -7,9 +7,8 @@ import (
 	"github.com/Songmu/prompter"
 	"github.com/kataras/golog"
 	rtmv1 "github.com/sonr-io/sonr/third_party/types/motor/api/v1"
-	"github.com/sonr-io/speedway/internal/binding"
+	"github.com/sonr-io/speedway/internal/client"
 	"github.com/sonr-io/speedway/internal/status"
-	"github.com/sonr-io/speedway/internal/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -30,19 +29,18 @@ func bootstrapCreateAccountCommand(ctx context.Context, logger *golog.Logger) (c
 				NoEcho:  true,
 			}).Prompt()
 
-			req := rtmv1.CreateAccountRequest{
-				Password: password,
+			cli, err := client.New(ctx)
+			if err != nil {
+				logger.Fatalf(status.Error("RPC Client Error: "), err)
+				return
 			}
-			logger.Info(status.Debug, "Create Account Request: ", req)
 
-			m := binding.InitMotor()
-			res, err := utils.CreateAccount(m, req)
+			res, err := cli.CreateAccount(rtmv1.CreateAccountRequest{Password: password})
 			if err != nil {
 				logger.Fatalf(status.Error("CreateAccount Error: "), err)
 				return
 			}
 
-			logger.Info(status.Debug, "Create Account Response: ", res)
 			logger.Info(status.Info, "Account Address: ", res.Address)
 		},
 	}

--- a/cmd/speedway-cli/speedwaycmd/registry/register.go
+++ b/cmd/speedway-cli/speedwaycmd/registry/register.go
@@ -41,6 +41,7 @@ func bootstrapCreateAccountCommand(ctx context.Context, logger *golog.Logger) (c
 				return
 			}
 
+			logger.Info(status.Debug, "Create Account Response: ", res)
 			logger.Info(status.Info, "Account Address: ", res.Address)
 		},
 	}

--- a/cmd/speedway-cli/speedwaycmd/root.go
+++ b/cmd/speedway-cli/speedwaycmd/root.go
@@ -26,6 +26,8 @@ func bootstrapRootCommand(ctx context.Context, logger *golog.Logger) (rootCmd *c
 		For more information, visit https://docs.sonr.io/.`,
 	}
 
+	ctx = context.WithValue(ctx, "DAEMON_PORT", 6868)
+
 	rootCmd.AddCommand(registry.BootstrapRegistryCommand(ctx, logger))
 	rootCmd.AddCommand(schema.BootstrapSchemaCommand(ctx, logger))
 	rootCmd.AddCommand(object.BootstrapObjectCommand(ctx, logger))

--- a/internal/binding/binding.go
+++ b/internal/binding/binding.go
@@ -160,6 +160,10 @@ func (b *SpeedwayBinding) LoginWithKeys(req rtmv1.LoginWithKeysRequest) (rtmv1.L
 	return res, err
 }
 
+func (b *SpeedwayBinding) GetLoggedIn() bool {
+	return b.loggedIn
+}
+
 /*
  [DEPRECATED] Get the object and return a map of the object
 */

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/rpc"
 )
@@ -9,7 +11,16 @@ type RpcClient struct {
 	client *rpc.Client
 }
 
-func New(port int) (*RpcClient, error) {
+func New(ctx context.Context) (*RpcClient, error) {
+	port, ok := ctx.Value("DAEMON_PORT").(int)
+	if !ok {
+		return nil, errors.New("port not found")
+	}
+
+	return WithPort(port)
+}
+
+func WithPort(port int) (*RpcClient, error) {
 	client, err := rpc.Dial("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		return nil, err

--- a/internal/client/info.go
+++ b/internal/client/info.go
@@ -1,0 +1,16 @@
+package client
+
+import (
+	"github.com/sonr-io/speedway/internal/daemon"
+)
+
+func (c *RpcClient) GetSessionInfo() (*daemon.GetSessionInfoResponse, error) {
+	var (
+		request  daemon.GetSessionInfoRequest
+		response daemon.GetSessionInfoResponse
+	)
+	if err := c.client.Call("Daemon.GetSessionInfo", request, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}

--- a/internal/daemon/info.go
+++ b/internal/daemon/info.go
@@ -1,0 +1,22 @@
+package daemon
+
+// SessionInfo contains information about the daemon's session
+type SessionInfo struct {
+	Address  string
+	LoggedIn bool
+}
+
+type GetSessionInfoRequest struct{}
+type GetSessionInfoResponse struct {
+	Info SessionInfo
+}
+
+func (d *Daemon) GetSessionInfo(req GetSessionInfoRequest, res *GetSessionInfoResponse) error {
+	*res = GetSessionInfoResponse{
+		Info: SessionInfo{
+			Address:  d.instance.Instance.GetAddress(),
+			LoggedIn: d.instance.GetLoggedIn(),
+		},
+	}
+	return nil
+}


### PR DESCRIPTION
The first in a series of PRs to daemonize speedway.

- [x] Add command `speedway daemon start` to create an RPC server
- [x] Add registry RPC handlers for motor commands
- [x] Add schema RPC handlers for motor commands
- [x] Add bucket RPC handlers for motor commands
- [x] **Integrate daemon into registry commands**
- [ ] Integrate daemon into schema/object commands
- [ ] Integrate daemon into bucket commands
- [ ] Add support for init systems

## Changes

- Add `daemon` package and command.

Updates #155 

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>