### PR TITLE
Integrate daemon into schema commands

### DIFF
--- a/cmd/speedway-cli/speedwaycmd/schema/getschema.go
+++ b/cmd/speedway-cli/speedwaycmd/schema/getschema.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/sonr-io/speedway/internal/client"
 	"strings"
 
 	"github.com/Songmu/prompter"
 	"github.com/kataras/golog"
 	rtmv1 "github.com/sonr-io/sonr/third_party/types/motor/api/v1"
 	"github.com/sonr-io/speedway/internal/binding"
+	"github.com/sonr-io/speedway/internal/client"
 	"github.com/sonr-io/speedway/internal/prompts"
 	"github.com/sonr-io/speedway/internal/status"
 	"github.com/sonr-io/speedway/internal/utils"
@@ -54,13 +54,11 @@ func bootstrapQuerySchemaCommand(ctx context.Context, logger *golog.Logger) (que
 				return
 			}
 
-			querySchemaReq := rtmv1.QueryWhatIsRequest{
+			// query schema
+			querySchemaRes, err := cli.GetSchema(rtmv1.QueryWhatIsRequest{
 				Creator: session.Info.Address,
 				Did:     did,
-			}
-
-			// query schema
-			querySchemaRes, err := cli.GetSchema(querySchemaReq)
+			})
 			if err != nil {
 				fmt.Printf("Command failed %v\n", err)
 				return

--- a/internal/client/schema.go
+++ b/internal/client/schema.go
@@ -12,7 +12,7 @@ func (c *RpcClient) CreateSchema(req rtmv1.CreateSchemaRequest) (*rtmv1.CreateSc
 	return &response, nil
 }
 
-func (c *RpcClient) GetSchema(req rtmv1.QuerySchemaRequest) (*rtmv1.QueryWhatIsResponse, error) {
+func (c *RpcClient) GetSchema(req rtmv1.QueryWhatIsRequest) (*rtmv1.QueryWhatIsResponse, error) {
 	var response rtmv1.QueryWhatIsResponse
 	if err := c.client.Call("Daemon.GetSchema", req, &response); err != nil {
 		return nil, err

--- a/internal/daemon/schema.go
+++ b/internal/daemon/schema.go
@@ -11,7 +11,7 @@ func (d *Daemon) CreateSchema(req rtmv1.CreateSchemaRequest, res *rtmv1.CreateSc
 	return
 }
 
-func (d *Daemon) GetSchema(req rtmv1.QuerySchemaRequest, res *rtmv1.QueryWhatIsResponse) (err error) {
+func (d *Daemon) GetSchema(req rtmv1.QueryWhatIsRequest, res *rtmv1.QueryWhatIsResponse) (err error) {
 	*res, err = d.instance.GetSchema(context.Background(), req.Creator, req.Did)
 	return
 }


### PR DESCRIPTION
The first in a series of PRs to daemonize speedway.

- [x] Add command `speedway daemon start` to create an RPC server
- [x] Add registry RPC handlers for motor commands
- [x] Add schema RPC handlers for motor commands
- [x] Add bucket RPC handlers for motor commands
- [x] Integrate daemon into registry commands
- [x] Integrate daemon into schema commands
- [ ] Integrate daemon into object commands
- [ ] Integrate daemon into bucket commands
- [ ] Add support for init systems

Updates #155 

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>