### PR TITLE
Initial logic for schemas with list type

### DIFF
--- a/server-in-memory/go.test.js
+++ b/server-in-memory/go.test.js
@@ -78,6 +78,7 @@ it(
 				extinct: 1,
 				strength: 2,
 				interest: 3,
+				friends: 0,
 			},
 		})
 		expect(resSchemaCreate.status).toBe(200)
@@ -117,7 +118,7 @@ it(
 		expect(userSchemas[0]).toHaveProperty("schema.label")
 		expect(userSchemas[0].schema.label).toBe("dinosaurs")
 		expect(userSchemas[0]).toHaveProperty("schema.fields.length")
-		expect(userSchemas[0].schema.fields.length).toBe(4)
+		expect(userSchemas[0].schema.fields.length).toBe(5)
 
 		expect(userSchemas[0].schema.fields[0].name).toBe("firstname")
 		expect(userSchemas[0].schema.fields[0].field).toBe("STRING")
@@ -127,6 +128,8 @@ it(
 		expect(userSchemas[0].schema.fields[2].field).toBe("INT")
 		expect(userSchemas[0].schema.fields[3].name).toBe("interest")
 		expect(userSchemas[0].schema.fields[3].field).toBe("FLOAT")
+		expect(userSchemas[0].schema.fields[4].name).toBe("friends")
+		expect(userSchemas[0].schema.fields[4].field).toBe("LIST")
 
 		// GET A LIST OF BUCKETS
 		const resBucketList = await app.get(proxy("buckets"))
@@ -157,6 +160,7 @@ it(
 				firstname: "steve",
 				interest: 2.5,
 				strength: 10,
+				friends: ["robin", "nancy"],
 			},
 		})
 		expect(resObject.status).toBe(200)
@@ -191,7 +195,7 @@ it(
 		expect(resBucketContents.body.bucket[0].uri).toBe(objectCid)
 		expect(resBucketContents.body.bucket[0]).toHaveProperty("content.item")
 		expect(resBucketContents.body.bucket[0].content.item).toBe(
-			"eyJleHRpbmN0Ijp0cnVlLCJmaXJzdG5hbWUiOiJzdGV2ZSIsImludGVyZXN0IjoyLjUsInN0cmVuZ3RoIjoxMH0="
+			"eyJleHRpbmN0Ijp0cnVlLCJmaXJzdG5hbWUiOiJzdGV2ZSIsImZyaWVuZHMiOlsicm9iaW4iLCJuYW5jeSJdLCJpbnRlcmVzdCI6Mi41LCJzdHJlbmd0aCI6MTB9"
 		)
 	},
 	10 * 60 * 1000 // 10 minutes timeout

--- a/server-in-memory/server.js
+++ b/server-in-memory/server.js
@@ -14,6 +14,7 @@ const accountStoreKey = (address) => `account-${address}`
 const objectStoreKey = (cid) => `object-${cid}`
 
 const fieldTypeMap = {
+	0: "LIST",
 	1: "BOOL",
 	2: "INT",
 	3: "FLOAT",
@@ -238,11 +239,20 @@ app.post("/api/v1/object/build", async ({ body }, res) => {
 		return
 	}
 
+	const objectData = _.chain(body.object)
+		.keys()
+		.sortBy()
+		.reduce((acc, key) => {
+			acc[key] = body.object[key]
+			return acc
+		}, {})
+		.valueOf()
+
 	const cid = generateCid()
 	const object = {
 		cid,
 		schema: body.schemaDid,
-		...body.object,
+		...objectData,
 	}
 	await storage.setItem(objectStoreKey(cid), object)
 

--- a/src/pages/Objects/components/NewObjectModalContent/Component.tsx
+++ b/src/pages/Objects/components/NewObjectModalContent/Component.tsx
@@ -1,5 +1,5 @@
 import { Button, NebulaIcon } from "@sonr-io/nebula-react"
-import { Dispatch, SetStateAction } from "react"
+import { ChangeEvent, Dispatch, SetStateAction, useState } from "react"
 import { Bucket, SchemaField, SchemaMeta } from "../../../../utils/types"
 
 interface NewSchemaModalContentComponentProps {
@@ -142,6 +142,8 @@ type Props = {
 
 const SchemaFieldInput = ({ field, onChange }: Props) => {
 	switch (field.type) {
+		case 0:
+			return <ListInput onChange={onChange} />
 		case 1:
 			return (
 				<select
@@ -181,6 +183,33 @@ const SchemaFieldInput = ({ field, onChange }: Props) => {
 		default:
 			return <div className="italic text-subdued">Unrecognized field type</div>
 	}
+}
+
+const ListInput = ({ onChange }: { onChange: (value: string) => void }) => {
+	const [values, setValues] = useState<string[]>([""])
+	const addItem = () => setValues((values) => [...values, ""])
+	const onChangeItem =
+		(key: number) => (event: ChangeEvent<HTMLInputElement>) => {
+			setValues((values) => {
+				values[key] = event.target.value
+				return [...values]
+			})
+			onChange(JSON.stringify(values))
+		}
+	return (
+		<div>
+			{values.map((value, key) => (
+				<div>
+					<input
+						className="border border-black"
+						value={value}
+						onChange={onChangeItem(key)}
+					/>
+				</div>
+			))}
+			<button onClick={addItem}>Add item</button>
+		</div>
+	)
 }
 
 export default NewObjectModalContentComponent

--- a/src/pages/Objects/components/NewObjectModalContent/Container.tsx
+++ b/src/pages/Objects/components/NewObjectModalContent/Container.tsx
@@ -66,6 +66,8 @@ function NewObjectModalContentContainer({
 
 		const castValue = (type: Number, value: string) => {
 			switch (type) {
+				case 0:
+					return JSON.parse(value)
 				case 1:
 					if (value === "true") return true
 					if (value === "false") return false

--- a/src/pages/Schemas/components/SchemaPropertyLine/Component.tsx
+++ b/src/pages/Schemas/components/SchemaPropertyLine/Component.tsx
@@ -41,6 +41,7 @@ function SchemaPropertyComponent({
 					<option value="int">Integer</option>
 					<option value="float">Float</option>
 					<option value="boolean">Boolean</option>
+					<option value="list">List</option>
 				</select>
 				<NebulaIcon
 					iconName="ArrowSquareDown"

--- a/src/pages/Schemas/components/SchemaPropertyLine/Component.tsx
+++ b/src/pages/Schemas/components/SchemaPropertyLine/Component.tsx
@@ -41,7 +41,7 @@ function SchemaPropertyComponent({
 					<option value="int">Integer</option>
 					<option value="float">Float</option>
 					<option value="boolean">Boolean</option>
-					<option value="list">List</option>
+					{/* <option value="list">List</option> */}
 				</select>
 				<NebulaIcon
 					iconName="ArrowSquareDown"


### PR DESCRIPTION
- proving that from the UI we can create a schema and save an object that has a list (only strings for now)
- still need to add more features (like deleting items, proper UI etc...)
- option currently hidden from the UI