### PR TITLE
Fix Last Update on bucket list

### DIFF
--- a/server-in-memory/server.js
+++ b/server-in-memory/server.js
@@ -176,7 +176,7 @@ app.post("/api/v1/bucket/create", async ({ body }, res) => {
 		did,
 		label: body.label,
 		creator: body.creator,
-		timestamp: Date.now(),
+		timestamp: Math.round(Date.now() / 1000),
 		content: [],
 	}
 

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -1,2 +1,3 @@
 declare module "@sonr-io/nebula-react"
 declare module "react-drag-drop-files"
+declare module "node-time-ago"

--- a/src/pages/Buckets/Component.tsx
+++ b/src/pages/Buckets/Component.tsx
@@ -1,4 +1,6 @@
 import { useContext } from "react"
+import timeAgo from "node-time-ago"
+
 import LoadingCircleSvg from "../../assets/svgs/LoadingCircle"
 import EmptyList from "../../components/EmptyList"
 import LayoutMenu from "../../components/LayoutMenu"
@@ -8,8 +10,6 @@ import {
 } from "../../contexts/appModalContext/appModalContext"
 import { MODAL_CONTENT_NEW_BUCKET } from "../../utils/constants"
 import { Bucket } from "../../utils/types"
-
-const timeAgo = require("node-time-ago")
 
 type Props = {
 	data: Bucket[]
@@ -91,7 +91,7 @@ const BucketCard = (bucket: Bucket) => (
 		</div>
 
 		<div className="font-extrabold text-placeholder text-custom-xxs">
-			Last Update: {timeAgo(bucket.timestamp)}
+			Last Update: {timeAgo(parseInt(bucket.timestamp) * 1000)}
 		</div>
 	</div>
 )


### PR DESCRIPTION
- it was showing the wrong date because timestamp is in seconds, but UI was interpreting it as milliseconds

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>